### PR TITLE
在 Yggdrasil 中加入船新域名

### DIFF
--- a/advanced/yggdrasil.md
+++ b/advanced/yggdrasil.md
@@ -8,26 +8,11 @@ LittleSkin 提供 Yggdrasil 验证鉴权服务。你可以配合 [authlib-inject
 LittleSkin 的 Yggdrasil API 的地址是：
 
 ```
-# 中国大陆
-https://mcskin.littleservice.cn/api/yggdrasil
-
-# 海外
-https://littleskin.cn/api/yggdrasil
+https://littlesk.in/api/yggdrasil
 ```
 
-LittleSkin 已在全站启用 authlib-injector 的 API 地址指示（ALI）功能。在使用支持 ALI 的 authlib-injector 和启动器（如 [HMCL 3](https://www.mcbbs.net/thread-142335-1-1.html) 和 [BakaXL](https://www.mcbbs.net/thread-512144-1-1.html)）时，输入 LittleSkin 的任意页面的地址即可被识别。
+LittleSkin 已在全站启用 authlib-injector 的 API 地址指示（ALI）功能。在使用支持 ALI 的 authlib-injector 和启动器时，输入 LittleSkin 的任意页面的地址即可被识别。
 
-::: tip
-**记不住？**
-
-对于支持 ALI 的 authlib-injector 和启动器，你可以使用船新的地址：
-
-```
-https://littlesk.in/
-```
-
-该地址会指向适合你的 Yggdrasil API 地址。
-:::
 ## API 文档
 
 请参阅：[Yggdrasil 服务端技术规范](https://github.com/yushijinhun/authlib-injector/wiki/Yggdrasil%E6%9C%8D%E5%8A%A1%E7%AB%AF%E6%8A%80%E6%9C%AF%E8%A7%84%E8%8C%83)

--- a/advanced/yggdrasil.md
+++ b/advanced/yggdrasil.md
@@ -8,11 +8,26 @@ LittleSkin 提供 Yggdrasil 验证鉴权服务。你可以配合 [authlib-inject
 LittleSkin 的 Yggdrasil API 的地址是：
 
 ```
+# 中国大陆
 https://mcskin.littleservice.cn/api/yggdrasil
+
+# 海外
+https://littleskin.cn/api/yggdrasil
 ```
 
-LittleSkin 已在全站启用 authlib-injector 的 API 地址指示（ALI）功能。在使用支持 ALI 的 authlib-injector 和启动器时，输入 LittleSkin 的任意页面的地址即可被识别。
+LittleSkin 已在全站启用 authlib-injector 的 API 地址指示（ALI）功能。在使用支持 ALI 的 authlib-injector 和启动器（如 [HMCL 3](https://www.mcbbs.net/thread-142335-1-1.html) 和 [BakaXL](https://www.mcbbs.net/thread-512144-1-1.html)）时，输入 LittleSkin 的任意页面的地址即可被识别。
 
+::: tip
+**记不住？**
+
+对于支持 ALI 的 authlib-injector 和启动器，你可以使用船新的地址：
+
+```
+https://littlesk.in/
+```
+
+该地址会指向适合你的 Yggdrasil API 地址。
+:::
 ## API 文档
 
 请参阅：[Yggdrasil 服务端技术规范](https://github.com/yushijinhun/authlib-injector/wiki/Yggdrasil%E6%9C%8D%E5%8A%A1%E7%AB%AF%E6%8A%80%E6%9C%AF%E8%A7%84%E8%8C%83)
@@ -37,7 +52,7 @@ LittleSkin 已在全站启用 authlib-injector 的 API 地址指示（ALI）功�
 
 ## 在客户端使用
 
-在客户端中使用 LittleSkin 的 Yggdrasil 需要启动器支持自定义 Yggdrasil 服务器。推荐使用 [HMCL](https://www.mcbbs.net/thread-142335-1-1.html) 和 [BakaXL](https://www.mcbbs.net/thread-512144-1-1.html)。
+在客户端中使用 LittleSkin 的 Yggdrasil 需要启动器支持自定义 Yggdrasil 服务器。推荐使用 [HMCL 3](https://www.mcbbs.net/thread-142335-1-1.html) 和 [BakaXL](https://www.mcbbs.net/thread-512144-1-1.html)。
 
 ::: tip
 如果你使用的启动器不支持自定义 Yggdrasil，并且你使用的启动器是使用 Java 编写的，你也可以手动添加 JVM 参数来加载 authlib-injector（就像在服务端使用 authlib-injector 一样），但是这篇文档不介绍这种做法。


### PR DESCRIPTION
同时将 `HMCL` 改为 `HMCL 3`
> HMCL 2 并不支持 Ygg
> ![鱼鱼说的](https://user-images.githubusercontent.com/34389622/86505556-bede4c00-bdf8-11ea-9fa7-0ecff46d07a4.png)

